### PR TITLE
Quick fix on Sparkle.js CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are 4 ways to get started with the Sparkle framework:
 </head>
 <body>
     <!-- Your body scripts here -->
-    <script src="https://gitcdn.xyz/repo/jdriviere/sparkle-css/blob/master/dist/js/sparkle.min.css"></script>
+    <script src="https://gitcdn.link/repo/jdriviere/sparkle-css/master/dist/js/sparkle.min.js"></script>
 </body>
 ```
 (You will need both links to ensure Sparkle works efficiently, as it uses the jQuery.)

--- a/gettingstarted.html
+++ b/gettingstarted.html
@@ -121,7 +121,7 @@
                     &lt;link rel="stylesheet" href="https://gitcdn.link/repo/jdriviere/sparkle-css/master/dist/css/sparkle.min.css" &gt;
                     <br>...<br>
                     &lt;!-- Your body scripts here --&gt;<br>
-                    &lt;script src="https://gitcdn.xyz/repo/jdriviere/sparkle-css/blob/master/dist/js/sparkle.min.css"&gt;&lt;/script&gt;
+                    &lt;script src="https://gitcdn.xyz/repo/jdriviere/sparkle-css/master/dist/js/sparkle.min.css"&gt;&lt;/script&gt;
                 </code>
                 <br><br>(Note: You will need both links to ensure Sparkle works efficiently, as it uses the jQuery.)
             </div>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
     <!-- LOADING SCRIPTS - Note: At the bottom of <body> makes scripts load faster -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://use.fontawesome.com/a833db4ecd.js"></script>
-    <!--<script src="https://gitcdn.xyz/repo/jdriviere/sparkle-css/blob/master/dist/js/sparkle.min.css"></script>-->
-    <script src="dist/js/sparkle.min.js"></script>
+    <script src="https://gitcdn.link/repo/jdriviere/sparkle-css/master/dist/js/sparkle.min.js"></script>
+    <!-- <script src="dist/js/sparkle.min.js"></script> -->
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sparkle.css",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Simple CSS framework coded in CSS and jQuery",
   "main": "sparkle.min.css",
   "scripts": {


### PR DESCRIPTION
Just a quick fix on the Sparkle.js CDN link